### PR TITLE
Add file extension at the end of files

### DIFF
--- a/magni.js
+++ b/magni.js
@@ -426,9 +426,12 @@ document.addEventListener('keydown', function (e) {
 
         let quality = 1;
         let image = printCanvasElem.toDataURL("image/png",quality).replace("image/png", "image/octet-stream"); // here is the most important part because if you dont replace you will get a DOM 18 exception.
-
-        window.location.href=image; // it will save locally
-
+        let element = document.createElement('a');
+        element.download = image.slice(100, 110) + ".png";
+        element.href = image;
+        document.body.appendChild(element);
+        element.click();
+        element.remove();
     }
 
     if (e.code === "ControlLeft") { //toggle for grid


### PR DESCRIPTION
This creates a temporary "a" on which the href attribute is set to the
image and the filename as download attribute.
The element is then clicked to download it and removed afterwards.
The filename is created by taking the 100th to the 110th character in
the image.
Closes #7